### PR TITLE
Use camelCase for aws db property

### DIFF
--- a/rule-packs/aws-config.json
+++ b/rule-packs/aws-config.json
@@ -110,7 +110,7 @@
     "queries": [
       {
         "name": "query0",
-        "query": "Find (aws_db_instance|aws_rds_cluster) with BackupRetentionPeriod=undefined",
+        "query": "Find (aws_db_instance|aws_rds_cluster) with backupRetentionPeriod=undefined",
         "version": "v1"
       }
     ]


### PR DESCRIPTION
this caused a false positive in alerts, since we recently normalized the properties to camelCase