### PR TITLE
Updating question defintions prior to releasing DeMorgan's law fix

### DIFF
--- a/rule-packs/gcp.json
+++ b/rule-packs/gcp.json
@@ -28,7 +28,7 @@
         "queries": [
           {
             "name": "query0",
-            "query": "find google_iam_service_account as user\n  that ASSIGNED google_iam_role\n  with name!~=(\n    \"admin\" or\n    \"Admin\"\n  ) and name!=(\n    \"roles/owner\" or\n    \"roles/editor\"\n  )\nreturn\n  user.name,\n  user.username,\n  user.email,\n  google_iam_role.name",
+            "query": "find google_iam_service_account as user\n  that ASSIGNED google_iam_role\n  with name!~=(\n    \"admin\" and\n    \"Admin\"\n  ) and name!=(\n    \"roles/owner\" and\n    \"roles/editor\"\n  )\nreturn\n  user.name,\n  user.username,\n  user.email,\n  google_iam_role.name",
             "version": "v1"
           }
         ]


### PR DESCRIPTION
Updating questions to reflect changes to language interpolation of negated shorthand filters to reflect DeMorgan's law. This includes flipping all AND/OR operators within a shorthand filter when negated equality is uses.

Other repositories with defined questions impacted by this ticket:
docs
insights-dashboard
integration-google-cloud
jupiter-integration-aws
jupiter-integration-jira
jupiterone-alert-rules
provision-managed-questions