### PR TITLE
adding rule account-part-of-organizations

### DIFF
--- a/rule-packs/aws-config.json
+++ b/rule-packs/aws-config.json
@@ -296,5 +296,16 @@
         "version": "v1"
       }
     ]
+  },
+  {
+    "name": "account-part-of-organizations",
+    "description": "Checks if an AWS account is part of AWS Organizations.",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "Find aws_account with _source!='system-mapper' that !has aws_account with master=true",
+        "version": "v1"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adding rule: account-part-of-organizations 
Purpose: Rule will check if an AWS account is part of AWS Organizations.

Verified with Akash and George prior to sending. 