### PR TITLE
Update aws-config.json

### DIFF
--- a/rule-packs/aws-config.json
+++ b/rule-packs/aws-config.json
@@ -421,7 +421,7 @@
     "queries": [
       {
         "name": "query0",
-        "query": "FIND aws_iam_user WITH mfaEnabled != true",
+        "query": "FIND aws_iam_user WITH mfaEnabled != true AND passwordEnabled = true",
         "version": "v1"
       }
     ],


### PR DESCRIPTION
mfa does not need to be enabled on aws_iam_user without a passwordEnabled The original version of this query was returning false positives including aws_iam_useer without the ability to login with a password. key access does not require mfa.

## QA Checklist

### Alerts Rule Packs
- [ ] Does a related alert already exist, and should it be tweaked or added to instead?
- [ ] Test each query to make sure it works
- [ ] Look for hardcoded variables/parameter values in the query
- [ ] Consider Severity for Alerts
- [ ] Spellcheck
- [ ] Use all caps for J1QL keywords and relationship classes
- [ ] Upload the alerts rule pack JSON into JupiterOne to validate