### PR TITLE
AlertRule Pack for J1 Integration Failures

### DIFF
--- a/rule-packs/intergration-monitoring.json
+++ b/rule-packs/intergration-monitoring.json
@@ -1,0 +1,16 @@
+{
+    "name": "jupiterone-integration-failures",
+    "description": "Integrations have failed to run or are in a hung state.",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "find jupiterone_integration with ((status='IN_PROGRESS' and _beginOn < date.now - 2 day) OR status = 'FAILED') AND pollingInterval!='DISABLED'",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "INFO",
+    "templates": {
+      "emailBody": "({{itemIndex+1}} of {{itemCount}}) <br><b>{{item.displayName}}</b><br>---<br><b>Integration:</b>{{item.integrationType}}<br><b>InstanceId:</b> {{item.id}}<br><b>Status:</b> {{item.status}}<br><b>PollingInterval:</b> {{item.pollingInterval}}<br><b>URL:</b> https://apps.us.jupiterone.io/integrations/{{item.integrationType}}/{{item.id}}/jobs<br><br>",
+      "slackBody": "({{itemIndex+1}} of {{itemCount}}) \n*{{item.displayName}}*\n---\n*Integration:* {{item.integrationType}}\n*InstanceId:* {{item.id}}\n*Status:* {{item.status}}\n *PollingInterval:* {{item.pollingInterval}}\n *URL:* https://apps.us.jupiterone.io/integrations/{{item.integrationType}}/{{item.id}}/jobs \n\n"
+    }
+}


### PR DESCRIPTION
## QA Checklist

### Alerts Rule Packs
- [x] Does a related alert already exist, and should it be tweaked or added to instead?
- [x] Test each query to make sure it works
- [x] Look for hardcoded variables/parameter values in the query
- [x] Consider Severity for Alerts
- [x] Spellcheck
- [x] Use all caps for J1QL keywords and relationship classes
- [x] Upload the alerts rule pack JSON into JupiterOne to validate