### PR TITLE
Update aws-threat.json for greater accuracy

### DIFF
--- a/rule-packs/aws-threat.json
+++ b/rule-packs/aws-threat.json
@@ -62,7 +62,7 @@
     "queries": [
       {
         "name": "query0",
-        "query": "find Internet\n  that CONNECTS aws_cloudfront_distribution with active=true as cloudfront\n  that CONNECTS aws_s3_bucket with classification!='public' as s3\nreturn\n  s3.bucketName, s3.tag.AccountName, s3.ownerId, s3.owner, s3.webLink,\n  cloudfront.domainName, cloudfront.tag.AccountName, cloudfront.webLink",
+        "query": "find Internet\n  that CONNECTS aws_cloudfront_distribution with active=true as cloudfront\n  that CONNECTS aws_s3_bucket with public = true as s3\nreturn\n  s3.bucketName, s3.tag.AccountName, s3.ownerId, s3.owner, s3.webLink,\n  cloudfront.domainName, cloudfront.tag.AccountName, cloudfront.webLink",
         "version": "v1"
       }
     ],


### PR DESCRIPTION
Current rule for aws-threat.json "name": "aws-s3-public-access-via-cloudfront" locates correctly set up connections, updated query to detect what it should detect.

## QA Checklist

### Alerts Rule Packs
- [x] Does a related alert already exist, and should it be tweaked or added to instead?
- [x] Test each query to make sure it works
- [x] Look for hardcoded variables/parameter values in the query
- [x] Consider Severity for Alerts
- [x] Spellcheck
- [x] Use all caps for J1QL keywords and relationship classes
- [x] Upload the alerts rule pack JSON into JupiterOne to validate