### PR TITLE
APP-14817 - Fix trellix queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/jupiterone-alert-rules",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Alert rule packages for the JupiterOne platform",
   "scripts": {
     "validate": "tsx ./scripts/validate.ts"

--- a/rule-packs/trellix-endpoint-security.json
+++ b/rule-packs/trellix-endpoint-security.json
@@ -1,110 +1,110 @@
 [
-    {
-        "name": "trellix-threats-1",
-        "description": "This query will return threats with an unresolved status",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_threat WITH status = 'unresolved'",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "MEDIUM"
-    },
-    {
-        "name": "trellix-threats-2",
-        "description": "This query will return unresolved threats with a criticality status of major or higher",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_threat WITH status = ('Critical' or 'Major')",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "HIGH"
-    },
-    {
-        "name": "trellix-threats-3",
-        "description": "This query will return threats that require immediate attention due to a failure to quarantine or remove",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_threat WITH remediationStatus = ('removedFailed' or 'quarantineFailed')",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "MEDIUM"
-    },
-    {
-        "name": "trellix-threats-4",
-        "description": "This will return Devices that have a non-compliant software status",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_device THAT INSTALLED trellix_detected_application with complianceStatus = false",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "MEDIUM"
-    },
-    {
-        "name": "trellix-threats-5",
-        "description": "This will return trellix endpoints that do not have a trellix agent installed",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_device THAT !INSTALLED trellix_detected_application",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "MEDIUM"
-    },
-    {
-        "name": "trellix-threats-6",
-        "description": "This will return trellix endpoints that have not reported a threat in the last 2 weeks. This may be due to a device that is no longer active, or is reporting incorrectly.",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_device THAT EXPLOITS << trellix_threat WITH createdOn > DATE.now - 14 days",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "INFO"
-    },
-    {
-        "name": "trellix-threats-7",
-        "description": "This will alert when a device is First Seen.",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_device WITH createdOn < DATE.now - 24 hours as device return device.name, device.user",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "INFO"
-    },
-    {
-        "name": "trellix-threats-8",
-        "description": "All devices should be under a group. This will notifiy if a trellix device is not associated with a trellix group",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND trellix_device THAT !ASSIGNED trellix_group",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "MEDIUM"
-    },
-    {
-        "name": "trellix-threats-9",
-        "description": "Look for potential Expired API keys.",
-        "queries": [
-            {
-                "name": "query0",
-                "query": "FIND (trellix_apiKey|trellix_mobileApiKey) WITH expiredOn = true OR startDate > DATE.now - 365 days",
-                "version": "v1"
-            }
-        ],
-        "alertLevel": "MEDIUM"
-    }
+  {
+    "name": "trellix-threats-1",
+    "description": "This query will return threats with an unresolved status",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_threat WITH status = 'unresolved'",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "MEDIUM"
+  },
+  {
+    "name": "trellix-threats-2",
+    "description": "This query will return unresolved threats with a criticality status of major or higher",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_threat WITH status = ('Critical' or 'Major')",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "HIGH"
+  },
+  {
+    "name": "trellix-threats-3",
+    "description": "This query will return threats that require immediate attention due to a failure to quarantine or remove",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_threat WITH remediationStatus = ('removedFailed' or 'quarantineFailed')",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "MEDIUM"
+  },
+  {
+    "name": "trellix-threats-4",
+    "description": "This will return Devices that have a non-compliant software status",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_device THAT INSTALLED trellix_detected_application with complianceStatus = false",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "MEDIUM"
+  },
+  {
+    "name": "trellix-threats-5",
+    "description": "This will return trellix endpoints that do not have a trellix agent installed",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_device THAT !INSTALLED trellix_detected_application",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "MEDIUM"
+  },
+  {
+    "name": "trellix-threats-6",
+    "description": "This will return trellix endpoints that have not reported a threat in the last 2 weeks. This may be due to a device that is no longer active, or is reporting incorrectly.",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_device THAT EXPLOITS << trellix_threat WITH createdOn > date.now - 14 days",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "INFO"
+  },
+  {
+    "name": "trellix-threats-7",
+    "description": "This will alert when a device is First Seen.",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_device WITH createdOn < date.now - 24 hours as device return device.name, device.user",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "INFO"
+  },
+  {
+    "name": "trellix-threats-8",
+    "description": "All devices should be under a group. This will notifiy if a trellix device is not associated with a trellix group",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND trellix_device THAT !ASSIGNED trellix_group",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "MEDIUM"
+  },
+  {
+    "name": "trellix-threats-9",
+    "description": "Look for potential Expired API keys.",
+    "queries": [
+      {
+        "name": "query0",
+        "query": "FIND (trellix_apiKey|trellix_mobileApiKey) WITH expiredOn = true OR startDate > date.now - 365 days",
+        "version": "v1"
+      }
+    ],
+    "alertLevel": "MEDIUM"
+  }
 ]


### PR DESCRIPTION
The query validator didn't pick up on this but it looks like `DATE`  in capitals isn't valid - got this error when trying to import the rule pack: 

```
"Error parsing query. Unexpected token \"DATE\" at line 1 column 81. \n> 1 | FIND (trellix_apiKey|trellix_mobileApiKey) WITH expiredOn = true OR startDate > DATE.now - 365 days\n    |                                                                                 ^^^^"
```


## QA Checklist

### Alerts Rule Packs

- [x] IF THIS CONTENT NEEDS TO BE RELEASED - is the package version in the package.json bumped?
- [ ] Does a related alert already exist, and should it be tweaked or added to instead?
- [ ] Test each query to make sure it works
- [ ] Look for hardcoded variables/parameter values in the query
- [ ] Consider Severity for Alerts
- [ ] Spellcheck
- [ ] Use all caps for J1QL keywords and relationship classes
- [ ] Upload the alerts rule pack JSON into JupiterOne to validate
