### PR TITLE
Remove tree  from rule pack

### DIFF
--- a/rule-packs/azure.json
+++ b/rule-packs/azure.json
@@ -262,7 +262,7 @@
             "version": "v1"
           }
         ]
-    }, 
+    },
     {
         "name": "azure-sql-encryption-rest",
         "description": "Finds Azure SQL servers which aren't encrypted at rest.",
@@ -302,7 +302,7 @@
         "queries": [
           {
             "name": "query0",
-            "query": "find Internet that allows as rule azure_security_group\n  that protects * that (has|contains|connects|uses) *\nreturn tree",
+            "query": "find Internet that allows as rule azure_security_group\n  that protects * that (has|contains|connects|uses) *",
             "version": "v1"
           }
         ]
@@ -384,4 +384,4 @@
         }
       ]
   }
-] 
+]


### PR DESCRIPTION
This was causing the rule to fail since you shouldn't be returning tree in the query for a rule

## QA Checklist

### Alerts Rule Packs

- [ ] IF THIS CONTENT NEEDS TO BE RELEASED - is the package version in the package.json bumped?
- [ ] Does a related alert already exist, and should it be tweaked or added to instead?
- [ ] Test each query to make sure it works
- [ ] Look for hardcoded variables/parameter values in the query
- [ ] Consider Severity for Alerts
- [ ] Spellcheck
- [ ] Use all caps for J1QL keywords and relationship classes
- [ ] Upload the alerts rule pack JSON into JupiterOne to validate
