### PR TITLE
TD-8001: Bump @jupiterone/query-language-parser to ^6.3.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "main": "index.js",
   "author": "JupiterOne <dev@jupiterone.io>",
   "devDependencies": {
-    "@jupiterone/query-language-parser": "^4.5.0",
+    "@jupiterone/query-language-parser": "^6.3.20",
     "@types/node": "^20.11.13",
     "euberlog": "^2.5.1",
     "tsx": "^4.7.0",

--- a/rule-packs/jupiterone-sbom.json
+++ b/rule-packs/jupiterone-sbom.json
@@ -29,7 +29,7 @@
     "queries": [
       {
         "name": "query0",
-        "query": "FIND (CodeRepo|CodeModule) AS parent THAT CONTAINS AS rel CodeModule AS cm RETURN parent.displayName, cm,displayName, rel.version",
+        "query": "FIND (CodeRepo|CodeModule) AS parent THAT CONTAINS AS rel CodeModule AS cm RETURN parent.displayName, cm.displayName, rel.version",
         "version": "v1"
       }
     ],


### PR DESCRIPTION
## Summary
- Bumps `@jupiterone/query-language-parser` to `^6.3.20`
- Required for **scalars in subqueries** feature support (parser fix in v6.3.20)
- Customers cannot save queries using scalar function returns in subqueries without this update

## Context
- Jira: [TD-8001](https://jupiterone.atlassian.net/browse/TD-8001)
- Parser fix: [query-language#1662](https://github.com/JupiterOne/query-language/pull/1662) (v6.3.20)

## Test plan
- [ ] Run `npm install` / `yarn install` to regenerate the lockfile
- [ ] Verify the project builds successfully
- [ ] Run existing tests to ensure no regressions
- [ ] Verify query with scalar function returns in subqueries parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TD-8001]: https://jupiterone.atlassian.net/browse/TD-8001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ